### PR TITLE
removed config volume from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ COPY entrypoint.sh /
 COPY copy.sh /
 COPY copy-abort.sh /
 
-VOLUME ["/config"]
-
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD [""]


### PR DESCRIPTION
I wasn't able to mount a volume as /config, so I removed the line and it worked afterwards.

Maybe I did something wrong in my compose file...

```
version: '3'

services:
   rclone-copy:
    image: roterfuu/docker-rclone-copy
    container_name: rclone-copy
    restart: always
    volumes:
        - /share/Container/rclone:/config
        - /share/homes/marcel/Google Fotos:/data
    environment: 
        - COPY_SRC=google-fotos:album
        - COPY_DEST=/data
        - CRON=30 8 * * 6
        - TZ=Europe/Berlin
```